### PR TITLE
Prevent output when user enters an input

### DIFF
--- a/v3/pg_logger.py
+++ b/v3/pg_logger.py
@@ -220,11 +220,6 @@ class RawInputException(Exception):
 def raw_input_wrapper(prompt=''):
   if input_string_queue:
     input_str = input_string_queue.pop(0)
-
-    # write the prompt and user input to stdout, to emulate what happens
-    # at the terminal
-    sys.stdout.write(str(prompt)) # always convert prompt into a string
-    sys.stdout.write(input_str + "\n") # newline to simulate the user hitting Enter
     return input_str
   raise RawInputException(str(prompt)) # always convert prompt into a string
 
@@ -233,11 +228,6 @@ def raw_input_wrapper(prompt=''):
 def python2_input_wrapper(prompt=''):
   if input_string_queue:
     input_str = input_string_queue.pop(0)
-
-    # write the prompt and user input to stdout, to emulate what happens
-    # at the terminal
-    sys.stdout.write(str(prompt)) # always convert prompt into a string
-    sys.stdout.write(input_str + "\n") # newline to simulate the user hitting Enter
     return eval(input_str) # remember to eval!
   raise RawInputException(str(prompt)) # always convert prompt into a string
 


### PR DESCRIPTION
Python tutor by default emulates terminal behavior by printing every input the user enters. In our user case this can be confusing so we eliminate that 