### PR TITLE
Fix python tutor and dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3
+ARG PYTHON=python:2
+FROM $PYTHON
 
 WORKDIR /usr/src/app
 
@@ -9,4 +10,6 @@ COPY . .
 EXPOSE 8003
 
 WORKDIR /usr/src/app/v3
-CMD [ "python3", "bottle_server.py" ]
+
+ENV PY_CMD python
+CMD $PY_CMD bottle_server.py

--- a/v3/bottle_server.py
+++ b/v3/bottle_server.py
@@ -13,12 +13,14 @@
 # compatibility from 2.x to 3.x Ii was running from /v3/).
 
 from bottle import route, get, request, run, template, static_file
-#import StringIO # NB: don't use cStringIO since it doesn't support unicode!!!
-import io
+
+try:
+    from StringIO import StringIO  # For Python 2
+except ImportError:
+    from io import StringIO  # For Python 3
 import json
 import pg_logger
 import urllib
-#import urllib2
 import os
 
 # dummy routes for testing only
@@ -40,7 +42,7 @@ def index(filepath):
 
 @get('/exec')
 def get_exec():
-  out_s = io.StringIO()
+  out_s = StringIO()
 
   def json_finalizer(input_code, output_trace):
     ret = dict(code=input_code, trace=output_trace)
@@ -48,7 +50,7 @@ def get_exec():
     out_s.write(json_output)
 
   options = json.loads(request.query.options_json)
-  print(request.query.user_script)
+
   pg_logger.exec_script_str_local(request.query.user_script,
                                   request.query.raw_input_json,
                                   options['cumulative_mode'],

--- a/v3/bottle_server.py
+++ b/v3/bottle_server.py
@@ -13,7 +13,6 @@
 # compatibility from 2.x to 3.x Ii was running from /v3/).
 
 from bottle import route, get, request, run, template, static_file
-
 try:
     from StringIO import StringIO  # For Python 2
 except ImportError:

--- a/v3/js/opt-frontend-common.js
+++ b/v3/js/opt-frontend-common.js
@@ -40,8 +40,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // -rwxr-xr-x 1 pgbovine pgbovine 2.5K Jul  5 22:46 web_exec_py2.py*
 // (most notably, only the owner of the file should have write
 //  permissions)
-// var python2_backend_script = 'web_exec_py2.py';
-// var python3_backend_script = 'web_exec_py3.py';
+//var python2_backend_script = 'web_exec_py2.py';
+//var python3_backend_script = 'web_exec_py3.py';
 
 // uncomment below if you're running on Google App Engine using the built-in app.yaml
 var python2_backend_script = 'exec_py2';

--- a/v3/js/opt-frontend-common.js
+++ b/v3/js/opt-frontend-common.js
@@ -40,12 +40,12 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // -rwxr-xr-x 1 pgbovine pgbovine 2.5K Jul  5 22:46 web_exec_py2.py*
 // (most notably, only the owner of the file should have write
 //  permissions)
-//var python2_backend_script = 'web_exec_py2.py';
-//var python3_backend_script = 'web_exec_py3.py';
+// var python2_backend_script = 'web_exec_py2.py';
+// var python3_backend_script = 'web_exec_py3.py';
 
 // uncomment below if you're running on Google App Engine using the built-in app.yaml
-var python2_backend_script = 'exec';
-var python3_backend_script = 'exec';
+var python2_backend_script = 'exec_py2';
+var python3_backend_script = 'exec_py3';
 
 // KRAZY experimental KODE!!! Use a custom hacked CPython interpreter
 var python2crazy_backend_script = 'web_exec_py2-crazy.py';
@@ -1632,8 +1632,12 @@ function executeCodeAndCreateViz(codeToExec,
     // hacky!
     if (backendScript === python2_backend_script) {
       frontendOptionsObj.lang = 'py2';
+      // Update to the actual backend script tu execute
+      backendScript = 'exec'
     } else if (backendScript === python3_backend_script) {
       frontendOptionsObj.lang = 'py3';
+      // Update to the actual backend script tu execute
+      backendScript = 'exec'
     } else if (backendScript === js_backend_script) {
       frontendOptionsObj.lang = 'js';
       jsonp_endpoint = JS_JSONP_ENDPOINT;

--- a/v3/js/pytutor.js
+++ b/v3/js/pytutor.js
@@ -554,15 +554,15 @@ ExecutionVisualizer.prototype.render = function() {
 
   if (this.params.editCodeBaseURL) {
     // kinda kludgy
-    var pyVer = '3'; // default
+    var pyVer = '2'; // default
     if (this.params.lang === 'js') {
       pyVer = 'js';
     } else if (this.params.lang === 'ts') {
       pyVer = 'ts';
     } else if (this.params.lang === 'java') {
       pyVer = 'java';
-    } else if (this.params.lang === 'py2') {
-      pyVer = '2';
+    } else if (this.params.lang === 'py3') {
+      pyVer = '3';
     } else if (this.params.lang === 'c') {
       pyVer = 'c';
     } else if (this.params.lang === 'cpp') {
@@ -590,7 +590,7 @@ ExecutionVisualizer.prototype.render = function() {
     } else if (this.params.lang === 'java') {
       this.domRoot.find('#langDisplayDiv').html('Java');
     } else if (this.params.lang === 'py2') {
-      this.domRoot.find('#langDisplayDiv').html('Python 3.3');
+      this.domRoot.find('#langDisplayDiv').html('Python 2.7');
     } else if (this.params.lang === 'py3') {
       this.domRoot.find('#langDisplayDiv').html('Python 3.3');
     } else if (this.params.lang === 'c') {


### PR DESCRIPTION
- Update the Dockerfile to accept build args so the python image is given via arguments, also the python command is given via runtime when the service is being deployed.
- Remove unnecessary code.
- Fix StringIO usage for python 2 and 3
- Fix to show the proper message of used python version when the code is being displayed.